### PR TITLE
Performance: score above 50

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,6 @@ import ReactDOM from "react-dom/client"
 import { BrowserRouter } from "react-router-dom"
 import { PersistGate } from "redux-persist/integration/react"
 
-import { Elements } from "@stripe/react-stripe-js"
-
-import { stripePromise } from "./utils/stripe/stripe.utils"
-
 import App from "./App"
 
 import {
@@ -22,9 +18,7 @@ root.render(
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
         <BrowserRouter>
-          <Elements stripe={stripePromise}>
-            <App />
-          </Elements>
+          <App />
         </BrowserRouter>
       </PersistGate>
     </Provider>

--- a/src/routes/Checkout/Checkout.component.tsx
+++ b/src/routes/Checkout/Checkout.component.tsx
@@ -12,6 +12,9 @@ import CheckoutProductPayment from "./CheckoutProductPayment/CheckoutProductPaym
 import EmptyCheckout from "./EmptyCheckout/EmptyCheckout.component"
 import PageBanner from "../../components/PageBanner/PageBanner.component"
 
+import { Elements } from "@stripe/react-stripe-js"
+import { stripePromise } from "../../utils/stripe/stripe.utils"
+
 import emptyBasket from "../../assets/images/basket-icon.png"
 
 interface CartItem {
@@ -35,7 +38,7 @@ const Checkout: FC = () => {
   const totalAmount = userLatestOrder.reduce((total, order) => total + order.price, 0)
 
   return (
-    <>
+    <Elements stripe={stripePromise}>
       <PageBanner label="Checkout" />
       <Breadcrumbs label="Checkout" />
       {cartItems.length > 0 ? (
@@ -119,7 +122,7 @@ const Checkout: FC = () => {
       ) : (
         <EmptyCheckout />
       )}
-    </>
+    </Elements>
   )
 }
 


### PR DESCRIPTION
### Actions:

1. **Move Stripe integration to lower level component**
Stripe is currently being loaded on home page startup. Moving it down in the component hierarchy improves performance scores.

### Results:
- **Before:** mobile: 34; desktop: 74
- **After:** mobile: 54; desktop: 91
- **Diffs:** mobile: +20; desktop: +17

### Evidence:
<img width="1004" alt="Screenshot 2024-01-19 at 14 11 19" src="https://github.com/RejaurRahman/roots/assets/48370302/f7b729f4-e53b-4ba8-95f0-3fa849d9bd65">
<img width="1677" alt="Screenshot 2024-01-19 at 14 14 02" src="https://github.com/RejaurRahman/roots/assets/48370302/0fe36791-aa32-43f0-a7c9-29b347acc027">
<img width="984" alt="Screenshot 2024-01-19 at 14 18 18" src="https://github.com/RejaurRahman/roots/assets/48370302/bb7ad5b7-4e38-47a3-a734-938d0805942a">